### PR TITLE
Fix to match documentation

### DIFF
--- a/lib/core/manager.js
+++ b/lib/core/manager.js
@@ -146,9 +146,17 @@ manager.prototype.add = function(type, args) {
   }
 }
 
+/** @method transformWithString
+Transform an existing canvas into a NexusUI widget using its id. This method is a simple alternate of nx.transform(canvas,type) using the id instead of the DOM node. See that method for full documentation.
+@param {string} [canvasID] The ID of the canvas to be transformed.
+ */
+manager.prototype.transformWithString = function(canvasID, type) {
+	return this.transform(document.getElementById(canvasID), type);
+}
+
 /** @method transform 
 Transform an existing canvas into a NexusUI widget.
-@param {string} [canvasID] The ID of the canvas to be transformed.
+@param {DOMNode<canvas>} [canvas] The canvas DOM node to be transformed.
 @param {string} [type] (Optional.) Specify which type of widget the canvas will become. If no type is given, the canvas must have an nx attribute with a valid widget type.
 */
 manager.prototype.transform = function(canvas, type) {


### PR DESCRIPTION
Hey Ben and Jesse,

So I found a tiny discrepancy in the documentation. ``nx.transform`` takes a DOM element, not a string as it says in the documentation. I opted to add an alternate method that takes a string, and then modify the documentation to properly reflect what the method does. You know, to prevent breaking backwards compatibility and all.

Feel free to change to suit your JavaScript style.