### PR TITLE
Fix positoin typo in RangeSlider.resize()

### DIFF
--- a/lib/components/rangeslider.js
+++ b/lib/components/rangeslider.js
@@ -126,7 +126,7 @@ export default class RangeSlider extends Interface  {
     this.arrowR.setAttribute('x',this.bar.getAttribute('width'));
     this.arrowR.setAttribute('y',0);
     if (this.mode==='drag') {
-      this.positoin.center.resize([0,this.width],[this.height,0]);
+      this.position.center.resize([0,this.width],[this.height,0]);
       this.position.size.resize([0,this.width],[this.height,0]);
     } else if (this.mode==='select') {
       this.position.center.resize([0,this.width],[this.height,0]);


### PR DESCRIPTION
Fixes https://github.com/nexus-js/ui/issues/164 🚑 