### PR TITLE
Visualization optimizing, framerate control, bug fix

### DIFF
--- a/lib/interfaces/meter.js
+++ b/lib/interfaces/meter.js
@@ -17,7 +17,8 @@ let Interface = require('../core/interface');
  *
  * @example
  * var meter = new Nexus.Meter('#target', {
- *   size: [75,75]
+ *   size: [75,75],
+ *   fps: 30
  * })
  * meter.connect(myWebAudioNode)
  *
@@ -32,7 +33,8 @@ export default class Meter extends Interface {
     let options = [];
 
     let defaults = {
-      size: [30, 100]
+      size: [30, 100],
+	  fps: undefined
     };
 
     super(arguments, options, defaults);
@@ -65,31 +67,51 @@ export default class Meter extends Interface {
   colorInterface() {
     this.canvas.element.style.backgroundColor = this.colors.fill;
   }
+  
+  /**
+  Set the refreshes per second. Defaults to 0 = max permitted by browser, typically 60. Values < 60 can be used to decrease cpu/gpu usage.
+  * @param framesPerSecond {number} New framerate
+  */
+  setFramerate(newFramerate) {
+	  this.settings.fps = newFramerate;
+	  this.canvas.setFramerate(newFramerate);
+  }
 
-  render() {
+  render(nowTime=performance.now()) {
     if (this.active) {
       requestAnimationFrame(this.render.bind(this));
+	  if (!this.canvas.refreshIntervalReached(nowTime)) return; //skip rendering until target framerate interval reached
     }
-
-    this.canvas.context.fillStyle = this.colors.fill;
-    this.canvas.context.fillRect(
+	
+	//cache some vals to microoptimize
+	const width = this.canvas.element.width;
+	const height = this.canvas.element.height;
+	const canvasContext = this.canvas.context;
+	
+    canvasContext.fillStyle = this.colors.fill;
+    canvasContext.fillRect(
       0,
       0,
-      this.canvas.element.width,
-      this.canvas.element.height
+      width,
+      height
     );
 
     for (let i = 0; i < this.analysers.length; i++) {
       if (this.source) {
-        this.analysers[i].getFloatTimeDomainData(this.dataArray);
+		//cache more vals to microoptimize
+		const dataArray = this.dataArray;
+		const dataArrayLength = this.dataArray.length;
+		
+		
+        this.analysers[i].getFloatTimeDomainData(dataArray);
 
         let rms = 0;
 
-        for (let i = 0; i < this.dataArray.length; i++) {
-          rms += this.dataArray[i] * this.dataArray[i];
+        for (let i = 0; i < dataArrayLength; i++) {
+          rms += dataArray[i] * dataArray[i];
         }
 
-        rms = Math.sqrt(rms / this.dataArray.length);
+        rms = Math.sqrt(rms / dataArrayLength);
 
         this.db = 20 * Math.log10(rms);
       } else if (this.db > -200 && this.db !== -Infinity) {
@@ -103,14 +125,14 @@ export default class Meter extends Interface {
       if (this.db > -70) {
         let linear = math.normalize(this.db, -70, 5);
         let exp = linear * linear;
-        let y = math.scale(exp, 0, 1, this.element.height, 0);
+        let y = math.scale(exp, 0, 1, height, 0);
 
-        this.canvas.context.fillStyle = this.colors.accent;
-        this.canvas.context.fillRect(
+        canvasContext.fillStyle = this.colors.accent;
+        canvasContext.fillRect(
           this.meterWidth * i,
           y,
-          this.meterWidth,
-          this.canvas.element.height - y
+          width,
+          height - y
         );
 
         //console.log("rendering...")

--- a/lib/interfaces/oscilloscope.js
+++ b/lib/interfaces/oscilloscope.js
@@ -40,9 +40,6 @@ export default class Oscilloscope extends Interface {
     this.analyser = null;
     this.bufferLength = 0;
     this.dataArray = null;
-	
-	this.lastRefreshTimeMS = 0;
-	this.refreshRateMS = this.fps ? Math.round(1000/this.fps) : 0;
 
     this.active = false;
 
@@ -52,9 +49,14 @@ export default class Oscilloscope extends Interface {
 
     this.render();
   }
+  
+  setFramerate(newFramerate) {
+	  this.settings.fps = newFramerate;
+	  this.canvas.setFramerate(newFramerate);
+  }
 
   buildFrame() {
-    this.canvas = new dom.SmartCanvas(this.parent);
+    this.canvas = new dom.SmartCanvas(this.parent, this.settings.fps);
     this.element = this.canvas.element;
   }
 
@@ -69,11 +71,7 @@ export default class Oscilloscope extends Interface {
   render(nowTime=performance.now()) {
     if (this.active) {
       requestAnimationFrame(this.render.bind(this));
-	  if (!this.refreshRateMS || ((nowTime - this.lastRefreshTimeMS) >= this.refreshRateMS)) {
-		  this.lastRefreshTimeMS = nowTime;
-	  } else {
-		  return; //skip rendering until target framerate interval surpassed
-	  }
+	  if (!this.canvas.refreshIntervalReached(nowTime)) return; //skip rendering until target framerate interval reached
     }
 
     if (this.analyser) {
@@ -101,9 +99,10 @@ export default class Oscilloscope extends Interface {
     if (this.source) {
       var sliceWidth = width/this.bufferLength;
       var x = 0;
+	  const thisDataArray = this.dataArray;
 
       for (var i = 0; i < this.bufferLength; i++) {
-        var v = this.dataArray[i] / 128.0;
+        var v = thisDataArray[i] / 128.0;
         var y = (v * height) / 2;
 
         if (i === 0) {

--- a/lib/interfaces/oscilloscope.js
+++ b/lib/interfaces/oscilloscope.js
@@ -31,7 +31,8 @@ export default class Oscilloscope extends Interface {
     let options = [];
 
     let defaults = {
-      size: [300, 150]
+      size: [300, 150],
+	  fps: undefined
     };
 
     super(arguments, options, defaults);
@@ -39,6 +40,9 @@ export default class Oscilloscope extends Interface {
     this.analyser = null;
     this.bufferLength = 0;
     this.dataArray = null;
+	
+	this.lastRefreshTimeMS = 0;
+	this.refreshRateMS = this.fps ? Math.round(1000/this.fps) : 0;
 
     this.active = false;
 
@@ -62,53 +66,63 @@ export default class Oscilloscope extends Interface {
     this.canvas.element.style.backgroundColor = this.colors.fill;
   }
 
-  render() {
+  render(nowTime=performance.now()) {
     if (this.active) {
       requestAnimationFrame(this.render.bind(this));
+	  if (!this.refreshRateMS || ((nowTime - this.lastRefreshTimeMS) >= this.refreshRateMS)) {
+		  this.lastRefreshTimeMS = nowTime;
+	  } else {
+		  return; //skip rendering until target framerate interval surpassed
+	  }
     }
 
     if (this.analyser) {
       this.analyser.getByteTimeDomainData(this.dataArray);
     }
+	
+	//cache some vals to microoptimize
+	const width = this.canvas.element.width;
+	const height = this.canvas.element.height;
+	const canvasContext = this.canvas.context;
 
-    this.canvas.context.fillStyle = this.colors.fill;
-    this.canvas.context.fillRect(
+    canvasContext.fillStyle = this.colors.fill;
+    canvasContext.fillRect(
       0,
       0,
-      this.canvas.element.width,
-      this.canvas.element.height
+      width,
+      height
     );
 
-    this.canvas.context.lineWidth = ~~(this.height / 100 + 2);
-    this.canvas.context.strokeStyle = this.colors.accent;
+    canvasContext.lineWidth = ~~(height / 100 + 2);
+    canvasContext.strokeStyle = this.colors.accent;
 
-    this.canvas.context.beginPath();
+    canvasContext.beginPath();
 
     if (this.source) {
-      var sliceWidth = (this.canvas.element.width * 1.0) / this.bufferLength;
+      var sliceWidth = width/this.bufferLength;
       var x = 0;
 
       for (var i = 0; i < this.bufferLength; i++) {
         var v = this.dataArray[i] / 128.0;
-        var y = (v * this.canvas.element.height) / 2;
+        var y = (v * height) / 2;
 
         if (i === 0) {
-          this.canvas.context.moveTo(x, y);
+          canvasContext.moveTo(x, y);
         } else {
-          this.canvas.context.lineTo(x, y);
+          canvasContext.lineTo(x, y);
         }
 
         x += sliceWidth;
       }
     } else {
-      this.canvas.context.moveTo(0, this.canvas.element.height / 2);
-      this.canvas.context.lineTo(
-        this.canvas.element.width,
-        this.canvas.element.height / 2
+      canvasContext.moveTo(0, height / 2);
+      canvasContext.lineTo(
+        width,
+        height / 2
       );
     }
 
-    this.canvas.context.stroke();
+    canvasContext.stroke();
   }
 
   /**

--- a/lib/interfaces/oscilloscope.js
+++ b/lib/interfaces/oscilloscope.js
@@ -16,7 +16,8 @@ let Interface = require('../core/interface');
  *
  * @example
  * var oscilloscope = new Nexus.Oscilloscope('#target',{
- *   'size': [300,150]
+ *   size: [300,150],
+ *   fps: 30
  * })
  * oscilloscope.connect(myWebAudioNode)
  *
@@ -49,11 +50,6 @@ export default class Oscilloscope extends Interface {
 
     this.render();
   }
-  
-  setFramerate(newFramerate) {
-	  this.settings.fps = newFramerate;
-	  this.canvas.setFramerate(newFramerate);
-  }
 
   buildFrame() {
     this.canvas = new dom.SmartCanvas(this.parent, this.settings.fps);
@@ -66,6 +62,15 @@ export default class Oscilloscope extends Interface {
 
   colorInterface() {
     this.canvas.element.style.backgroundColor = this.colors.fill;
+  }
+  
+  /**
+  Set the refreshes per second. Defaults to 0 = max permitted by browser, typically 60. Values < 60 can be used to decrease cpu/gpu usage.
+  * @param framesPerSecond {number} New framerate
+  */
+  setFramerate(newFramerate) {
+	  this.settings.fps = newFramerate;
+	  this.canvas.setFramerate(newFramerate);
   }
 
   render(nowTime=performance.now()) {
@@ -97,13 +102,18 @@ export default class Oscilloscope extends Interface {
     canvasContext.beginPath();
 
     if (this.source) {
-      var sliceWidth = width/this.bufferLength;
-      var x = 0;
+	  //cache more vals to microoptimize
+	  const bufferLength = this.bufferLength;
 	  const thisDataArray = this.dataArray;
+	  const halfHeight = height/2;
+	  
+      var sliceWidth = width/bufferLength;
+      var x = 0;
+	  
 
-      for (var i = 0; i < this.bufferLength; i++) {
+      for (var i = 0; i < bufferLength; i++) {
         var v = thisDataArray[i] / 128.0;
-        var y = (v * height) / 2;
+        var y = v * halfHeight;
 
         if (i === 0) {
           canvasContext.moveTo(x, y);

--- a/lib/interfaces/spectrogram.js
+++ b/lib/interfaces/spectrogram.js
@@ -16,7 +16,8 @@ let Interface = require('../core/interface');
  *
  * @example
  * var spectrogram = new Nexus.Spectrogram('#target',{
- *   'size': [300,150]
+ *   size: [300,150],
+ *   fps: 30
  * })
  * spectrogram.connect(myWebAudioNode)
  *
@@ -31,7 +32,8 @@ export default class Spectrogram extends Interface {
     let options = [];
 
     let defaults = {
-      size: [300, 150]
+      size: [300, 150],
+	  fps: undefined
     };
 
     super(arguments, options, defaults);
@@ -57,45 +59,65 @@ export default class Spectrogram extends Interface {
   colorInterface() {
     this.canvas.element.style.backgroundColor = this.colors.fill;
   }
+  
+  /**
+  Set the refreshes per second. Defaults to 0 = max permitted by browser, typically 60. Values < 60 can be used to decrease cpu/gpu usage.
+  * @param framesPerSecond {number} New framerate
+  */
+  setFramerate(newFramerate) {
+	  this.settings.fps = newFramerate;
+	  this.canvas.setFramerate(newFramerate);
+  }
 
-  render() {
+  render(nowTime=performance.now()) {
     if (this.active) {
       requestAnimationFrame(this.render.bind(this));
+	  if (!this.canvas.refreshIntervalReached(nowTime)) return; //skip rendering until target framerate interval reached
     }
 
     if (this.analyser) {
       this.analyser.getByteFrequencyData(this.dataArray);
     }
+	
+	//cache some vals to microoptimize
+	const width = this.canvas.element.width;
+	const height = this.canvas.element.height;
+	const canvasContext = this.canvas.context;
 
-    this.canvas.context.fillStyle = this.colors.fill;
-    this.canvas.context.fillRect(
+    canvasContext.fillStyle = this.colors.fill;
+    canvasContext.fillRect(
       0,
       0,
-      this.canvas.element.width,
-      this.canvas.element.height
+      width,
+      height
     );
 
     if (this.source && this.dataArray) {
       //console.log(this.dataArray);
-
-      let barWidth = this.canvas.element.width / this.bufferLength;
+	  
+	  //cache more vals to microoptimize
+	  const bufferLength = this.bufferLength;
+	  const dataArray = this.dataArray;
+	  const accentColor = this.colors.accent;
+		
+      let barWidth = width / bufferLength;
       let barHeight;
       let x = 0;
 
-      let definition = this.canvas.element.width / 50;
+      let definition = width / 50;
 
-      for (let i = 0; i < this.bufferLength; i = i + definition) {
+      for (let i = 0; i < bufferLength; i = i + definition) {
         barHeight = Math.max.apply(
           null,
-          this.dataArray.subarray(i, i + definition)
+          dataArray.subarray(i, i + definition)
         );
         barHeight /= 255;
-        barHeight *= this.canvas.element.height;
+        barHeight *= height;
 
-        this.canvas.context.fillStyle = this.colors.accent;
-        this.canvas.context.fillRect(
+        canvasContext.fillStyle = accentColor;
+        canvasContext.fillRect(
           x,
-          this.canvas.element.height - barHeight,
+          height - barHeight,
           barWidth * definition,
           barHeight
         );

--- a/lib/util/dom.js
+++ b/lib/util/dom.js
@@ -50,7 +50,7 @@ exports.SmartCanvas = function(parent, fps) {
   
   this.setFramerate = (newFramerate) => {
 	  this.millisecondsPerFrame = newFramerate ? 1000/newFramerate : 0;
-  }
+  };
   this.refreshIntervalReached = (currentTime) => {
 	  if (!this.millisecondsPerFrame) {
 		  return true;
@@ -58,7 +58,7 @@ exports.SmartCanvas = function(parent, fps) {
 		  this.lastRefreshTime = currentTime;
 		  return true;
 	  }
-  }
+  };
   this.setFramerate(fps);
 
 };

--- a/lib/util/dom.js
+++ b/lib/util/dom.js
@@ -37,11 +37,13 @@ exports.SmartCanvas = function(parent) {
 
   this.element = document.createElement('canvas');
   this.context = this.element.getContext('2d');
+  this.scale = window.devicePixelRatio || 1;
+  this.context.scale(this.scale, this.scale);
   parent.appendChild(this.element);
 
   this.resize = (w,h) => {
-    this.element.width = w*2;
-    this.element.height = h*2;
+    this.element.width = Math.floor(w * this.scale);
+    this.element.height = Math.floor(h * this.scale);
     this.element.style.width = w+'px';
     this.element.style.height = h+'px';
   };

--- a/lib/util/dom.js
+++ b/lib/util/dom.js
@@ -33,19 +33,32 @@ exports.locateTouch = (e,offset) => {
   };
 };
 
-exports.SmartCanvas = function(parent) {
+exports.SmartCanvas = function(parent, fps) {
 
   this.element = document.createElement('canvas');
   this.context = this.element.getContext('2d');
   this.scale = window.devicePixelRatio || 1;
-  this.context.scale(this.scale, this.scale);
+  this.lastRefreshTime = 0;  
   parent.appendChild(this.element);
 
   this.resize = (w,h) => {
-    this.element.width = Math.floor(w * this.scale);
-    this.element.height = Math.floor(h * this.scale);
+    this.element.width = w * this.scale;
+    this.element.height = h * this.scale;
     this.element.style.width = w+'px';
     this.element.style.height = h+'px';
   };
+  
+  this.setFramerate = (newFramerate) => {
+	  this.millisecondsPerFrame = newFramerate ? 1000/newFramerate : 0;
+  }
+  this.refreshIntervalReached = (currentTime) => {
+	  if (!this.millisecondsPerFrame) {
+		  return true;
+	  } else if ((currentTime - this.lastRefreshTime) >= this.millisecondsPerFrame) {
+		  this.lastRefreshTime = currentTime;
+		  return true;
+	  }
+  }
+  this.setFramerate(fps);
 
 };


### PR DESCRIPTION
The visualization methods included in NexusUI are handy but can consume significant cpu & gpu which can cannibalize page rendering resources when used in combination with other animations and/or intensive audio processing. I made some improvements others might find useful so I offer as a PR:

- Implemented an optional refresh rate limiting method in Meter, Oscilloscope, and Spectragram which can significantly reduce cpu/gpu hogging and allow flexibility in tweaking performance vs resource usage.
- I noticed `SmartCanvas` was erroneously always using pixel doubling even on non retina devices which led to needless overprecision/aliasing in many cases, so I fixed it to use `window.devicePixelRatio` as a more precise scaling factor instead to better handle all possible displays.
- Added some other low hanging fruit microoptimizations in the canvas rendering code to try and squeeze as much efficiency as possible.

No breaking changes to the API and the default behavior is unchanged (=rendering occurs at max framerate), but added an optional `fps` setting and `setFramerate` method to each visualization interface.