### PR TITLE
prevent dials & sliders from jumping/sticking in certain situations

### DIFF
--- a/lib/interfaces/dial.js
+++ b/lib/interfaces/dial.js
@@ -245,7 +245,7 @@ export default class Dial extends Interface {
 
       if (angle < 0 ) { angle += (Math.PI*2); }
 
-      if (this.mode === 'relative') {
+      if ((this.mode === "relative") && (this.position.direction === "radial")) {
         if (this.previousAngle !== false && Math.abs(this.previousAngle - angle) > 2) {
           if (this.previousAngle > 3) {
             angle = Math.PI*2;

--- a/lib/util/interaction.js
+++ b/lib/util/interaction.js
@@ -75,10 +75,10 @@ export class Handle {
 
   update(mouse) {
     if (this.mode==='relative') {
-      let increment = this.convertPositionToValue(mouse) - this.anchor;
-      if (Math.abs(increment) > 0.5) { increment = 0; }
-      this.anchor = mouse;
-      this.value = this.value + increment * this.sensitivity;
+	  let rawIncrement = this.convertPositionToValue(mouse) - this.anchor;
+	  let interpretedIncrement = ((Math.abs(rawIncrement) > 0.5) && (this.direction === "radial")) ? 0 : rawIncrement * this.sensitivity;
+	  this.anchor = mouse;
+	  this.value = this.value + interpretedIncrement;      
     } else {
       this.value = this.convertPositionToValue(mouse);
     }


### PR DESCRIPTION
Fixes #142 and some other edge cases with similar bad behavior, especially if the `sensitivity` property is set low. It looked like some code that was there only to accommodate radial dials was interfering with smooth sliding in other components that used the `Handle` class. For a demo of the bugs this fixes see https://codepen.io/keymapper/pen/WNGGwEx with some components with low sensitivity settings and try to click and drag fast especially with quick direction changes.